### PR TITLE
Add 1M and 4M data bit rate, change clk to 160MHz

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ Note: CANFD message lengths are as follows (expressed in hexadecimal):
 
 Note: Channel configuration commands must be sent before opening the channel. The channel must be opened before transmitting frames.
 
-This firmware currently does not provide any ACK/NACK feedback for serial commands.
-
 ## Building
 
 Firmware builds with GCC. Specifically, you will need gcc-arm-none-eabi, which

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ This repository contains sources for the slcan CANable 2.0 firmware. This firmwa
 - `S7` - Set nominal bitrate to 750k
 - `S8` - Set nominal bitrate to 1M
 - `S9` - Set nominal bitrate to 83.3k
+- `Y1` - Set data bitrate to 1M (CANFD only)
 - `Y2` - Set data bitrate to 2M (CANFD only) (default)
+- `Y4` - Set data bitrate to 4M (CANFD only)
 - `Y5` - Set data bitrate to 5M (CANFD only)
 - `M0` - Set mode to normal mode (default)
 - `M1` - Set mode to silent mode

--- a/inc/can.h
+++ b/inc/can.h
@@ -21,7 +21,9 @@ enum can_bitrate {
 
 // CANFD bitrates
 enum can_data_bitrate {
+    CAN_DATA_BITRATE_1M = 1,
     CAN_DATA_BITRATE_2M = 2,
+    CAN_DATA_BITRATE_4M = 4,
     CAN_DATA_BITRATE_5M = 5,
 
 	CAN_DATA_BITRATE_INVALID,

--- a/src/can.c
+++ b/src/can.c
@@ -108,7 +108,7 @@ void can_enable(void)
         can_handle.Init.NominalTimeSeg2 = bitrate_nominal.time_seg2;
         
         // FD only
-        can_handle.Init.DataPrescaler = bitrate_data.prescaler; // 2 for 5Mbit rate with 160 base clock
+        can_handle.Init.DataPrescaler = bitrate_data.prescaler;
         can_handle.Init.DataSyncJumpWidth = bitrate_data.sjw;
         can_handle.Init.DataTimeSeg1 = bitrate_data.time_seg1;
         can_handle.Init.DataTimeSeg2 = bitrate_data.time_seg2;
@@ -176,7 +176,7 @@ void can_set_data_bitrate(enum can_data_bitrate bitrate)
             break;
         case CAN_DATA_BITRATE_4M:
             bitrate_data.prescaler = 1;
-            bitrate_data.sjw = 1;
+            bitrate_data.sjw = 8;
             bitrate_data.time_seg1 = 30;
             bitrate_data.time_seg2 = 9;
             break;

--- a/src/can.c
+++ b/src/can.c
@@ -14,12 +14,20 @@
 // Private variables
 static FDCAN_HandleTypeDef can_handle;
 //static FDCAN_FilterTypeDef filter;
-static uint32_t prescaler;
-static uint32_t data_prescaler;
 enum can_bus_state bus_state;
 static uint8_t can_autoretransmit = ENABLE;
 static can_txbuf_t txqueue = {0};
 
+// Structure for CAN/FD bitrate configuration
+typedef struct can_bitrate_cfg_
+{
+    uint16_t prescaler;
+    uint8_t sjw;
+    uint8_t time_seg1;
+    uint8_t time_seg2;
+} can_bitrate_cfg_t;
+
+static can_bitrate_cfg_t bitrate_nominal, bitrate_data = {0};
 
 // Initialize CAN peripheral settings, but don't actually start the peripheral
 void can_init(void)
@@ -53,7 +61,7 @@ void can_init(void)
     GPIO_InitStruct.Pin = GPIO_PIN_8|GPIO_PIN_9;
     GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
     GPIO_InitStruct.Alternate = GPIO_AF9_FDCAN1;
     HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 
@@ -68,7 +76,9 @@ void can_init(void)
     filter.FilterMode = CAN_FILTERMODE_IDMASK;
     filter.FilterScale = CAN_FILTERSCALE_32BIT;
     filter.FilterActivation = ENABLE;*/
-
+    
+    // Reset the queue
+    memset(&txqueue, 0, sizeof(txqueue));
 
     // default to 125 kbit/s
     can_set_bitrate(CAN_BITRATE_125K);
@@ -84,37 +94,25 @@ void can_enable(void)
     if (bus_state == OFF_BUS)
     {
         can_handle.Init.ClockDivider = FDCAN_CLOCK_DIV1; // 144Mhz
-//        can_handle.Init.FrameFormat = FDCAN_FRAME_CLASSIC;
         can_handle.Init.FrameFormat = FDCAN_FRAME_FD_BRS;
 
 
-    	//can_handle.Init.Prescaler = prescaler;
-    	can_handle.Init.Mode = FDCAN_MODE_NORMAL;
-    	can_handle.Init.AutoRetransmission = can_autoretransmit;
+        can_handle.Init.Mode = FDCAN_MODE_NORMAL;
+        can_handle.Init.AutoRetransmission = can_autoretransmit;
         can_handle.Init.TransmitPause = DISABLE; // emz
         can_handle.Init.ProtocolException = DISABLE; // emz
 
-        can_handle.Init.NominalPrescaler = prescaler; // 170mhz base clock
-    	can_handle.Init.NominalSyncJumpWidth = 1;
-    	can_handle.Init.NominalTimeSeg1 = 14;
-    	can_handle.Init.NominalTimeSeg2 = 2;
+        can_handle.Init.NominalPrescaler = bitrate_nominal.prescaler;
+        can_handle.Init.NominalSyncJumpWidth = bitrate_nominal.sjw;
+        can_handle.Init.NominalTimeSeg1 = bitrate_nominal.time_seg1;
+        can_handle.Init.NominalTimeSeg2 = bitrate_nominal.time_seg2;
         
         // FD only
-        can_handle.Init.DataPrescaler = data_prescaler; // 2 for 5Mbit rate with 170 base clock
-        can_handle.Init.DataSyncJumpWidth = 1;
-        can_handle.Init.DataTimeSeg1 = 14;
-        can_handle.Init.DataTimeSeg2 = 2;
-        
-        // For other bitrates with prescaler changes:
-        // 2Mbits is same 14/2 with a prescalar of 5
-        // Probably would prefer to change the time quanta instead
+        can_handle.Init.DataPrescaler = bitrate_data.prescaler; // 2 for 5Mbit rate with 160 base clock
+        can_handle.Init.DataSyncJumpWidth = bitrate_data.sjw;
+        can_handle.Init.DataTimeSeg1 = bitrate_data.time_seg1;
+        can_handle.Init.DataTimeSeg2 = bitrate_data.time_seg2;
 
-    	//can_handle.Init.TimeTriggeredMode = DISABLE;
-    	//can_handle.Init.AutoBusOff = ENABLE;
-    	//can_handle.Init.AutoWakeUp = DISABLE;
-    	//can_handle.Init.ReceiveFifoLocked = DISABLE;
-    	//can_handle.Init.TransmitFifoPriority = DISABLE;
-        
         can_handle.Init.StdFiltersNbr = 0;
         can_handle.Init.ExtFiltersNbr = 0;
         can_handle.Init.TxFifoQueueMode = FDCAN_TX_FIFO_OPERATION;
@@ -122,9 +120,17 @@ void can_enable(void)
         
         HAL_FDCAN_Init(&can_handle);
 
+        // This is a must for high data bit rates, especially for isolated transceivers
+        HAL_FDCAN_ConfigTxDelayCompensation(
+            &can_handle,
+            can_handle.Init.DataPrescaler*can_handle.Init.DataTimeSeg1,
+            0);
+        HAL_FDCAN_EnableTxDelayCompensation(&can_handle);
+
         //HAL_CAN_ConfigFilter(&can_handle, &filter);
 
         HAL_FDCAN_Start(&can_handle);
+
         bus_state = ON_BUS;
 
         led_blue_on();
@@ -138,7 +144,7 @@ void can_disable(void)
     if (bus_state == ON_BUS)
     {
         HAL_FDCAN_Stop(&can_handle);
-
+        HAL_FDCAN_DeInit(&can_handle);
         bus_state = OFF_BUS;
 
         led_green_on();
@@ -156,13 +162,30 @@ void can_set_data_bitrate(enum can_data_bitrate bitrate)
 
     switch (bitrate)
     {
-        case CAN_DATA_BITRATE_2M:
-        	data_prescaler = 5;
+        case CAN_DATA_BITRATE_1M:
+            bitrate_data.prescaler = 4;
+            bitrate_data.sjw = 8;
+            bitrate_data.time_seg1 = 30;
+            bitrate_data.time_seg2 = 9;
             break;
-
+        case CAN_DATA_BITRATE_2M:
+            bitrate_data.prescaler = 2;
+            bitrate_data.sjw = 8;
+            bitrate_data.time_seg1 = 30;
+            bitrate_data.time_seg2 = 9;
+            break;
+        case CAN_DATA_BITRATE_4M:
+            bitrate_data.prescaler = 1;
+            bitrate_data.sjw = 1;
+            bitrate_data.time_seg1 = 30;
+            bitrate_data.time_seg2 = 9;
+            break;
         case CAN_DATA_BITRATE_5M:
         default:
-        	data_prescaler = 2;
+            bitrate_data.prescaler = 1;
+            bitrate_data.sjw = 6;
+            bitrate_data.time_seg1 = 24;
+            bitrate_data.time_seg2 = 7;
             break;
     }
 
@@ -182,35 +205,66 @@ void can_set_bitrate(enum can_bitrate bitrate)
     switch (bitrate)
     {
         case CAN_BITRATE_10K:
-        	prescaler = 1000;
+            bitrate_nominal.prescaler = 200;
+            bitrate_nominal.sjw = 8;
+            bitrate_nominal.time_seg1 = 70;
+            bitrate_nominal.time_seg2 = 9;
             break;
         case CAN_BITRATE_20K:
-        	prescaler = 500;
+            bitrate_nominal.prescaler = 100;
+            bitrate_nominal.sjw = 8;
+            bitrate_nominal.time_seg1 = 70;
+            bitrate_nominal.time_seg2 = 9;
             break;
         case CAN_BITRATE_50K:
-        	prescaler = 200;
+            bitrate_nominal.prescaler = 40;
+            bitrate_nominal.sjw = 8;
+            bitrate_nominal.time_seg1 = 70;
+            bitrate_nominal.time_seg2 = 9;
             break;
         case CAN_BITRATE_83_3K:
-        	prescaler = 120;
-        	break;
+            bitrate_nominal.prescaler = 24;
+            bitrate_nominal.sjw = 8;
+            bitrate_nominal.time_seg1 = 70;
+            bitrate_nominal.time_seg2 = 9;
+            break;
         case CAN_BITRATE_100K:
-            prescaler = 100;
+            bitrate_nominal.prescaler = 20;
+            bitrate_nominal.sjw = 8;
+            bitrate_nominal.time_seg1 = 70;
+            bitrate_nominal.time_seg2 = 9;
             break;
         case CAN_BITRATE_125K:
-            prescaler = 80;
+            bitrate_nominal.prescaler = 16;
+            bitrate_nominal.sjw = 8;
+            bitrate_nominal.time_seg1 = 70;
+            bitrate_nominal.time_seg2 = 9;
             break;
         case CAN_BITRATE_250K:
-            prescaler = 40;
+            bitrate_nominal.prescaler = 8;
+            bitrate_nominal.sjw = 8;
+            bitrate_nominal.time_seg1 = 70;
+            bitrate_nominal.time_seg2 = 9;
             break;
         case CAN_BITRATE_500K:
-            prescaler = 20;
+            bitrate_nominal.prescaler = 4;
+            bitrate_nominal.sjw = 8;
+            bitrate_nominal.time_seg1 = 70;
+            bitrate_nominal.time_seg2 = 9;
             break;
         case CAN_BITRATE_750K:
-            prescaler = 7;// THIS IS VERY INACCURATE!!! FIXME
+            bitrate_nominal.prescaler = 4;
+            bitrate_nominal.sjw = 5;
+            bitrate_nominal.time_seg1 = 46;
+            bitrate_nominal.time_seg2 = 6;
             break;
         case CAN_BITRATE_1000K:
+            bitrate_nominal.prescaler = 2;
+            bitrate_nominal.sjw = 8;
+            bitrate_nominal.time_seg1 = 70;
+            bitrate_nominal.time_seg2 = 9;
+            break;
         default:
-            prescaler = 10;
             break;
     }
 
@@ -228,9 +282,9 @@ void can_set_silent(uint8_t silent)
     }
     if (silent)
     {
-    	can_handle.Init.Mode = FDCAN_MODE_BUS_MONITORING; // !!!?!?!
+        can_handle.Init.Mode = FDCAN_MODE_BUS_MONITORING; // !!!?!?!
     } else {
-    	can_handle.Init.Mode = FDCAN_MODE_NORMAL;
+        can_handle.Init.Mode = FDCAN_MODE_NORMAL;
     }
 
     led_green_on();
@@ -247,9 +301,9 @@ void can_set_autoretransmit(uint8_t autoretransmit)
     }
     if (autoretransmit)
     {
-    	can_autoretransmit = ENABLE;
+        can_autoretransmit = ENABLE;
     } else {
-    	can_autoretransmit = DISABLE;
+        can_autoretransmit = DISABLE;
     }
 
     led_green_on();
@@ -260,57 +314,57 @@ void can_set_autoretransmit(uint8_t autoretransmit)
 // Send a message on the CAN bus. Called from USB ISR.
 uint32_t can_tx(FDCAN_TxHeaderTypeDef *tx_msg_header, uint8_t* tx_msg_data)
 {
-	// If when we increment the head we're going to hit the tail
-	// (if we're filling the last spot in the queue)
-	if( ((txqueue.head + 1) % TXQUEUE_LEN) == txqueue.tail)
-	{
-		error_assert(ERR_FULLBUF_CANTX);
-		return HAL_ERROR;
-	}
+    // If when we increment the head we're going to hit the tail
+    // (if we're filling the last spot in the queue)
+    if( ((txqueue.head + 1) % TXQUEUE_LEN) == txqueue.tail)
+    {
+        error_assert(ERR_FULLBUF_CANTX);
+        return HAL_ERROR;
+    }
 
-	// Convert length to bytes
-	uint32_t len = hal_dlc_code_to_bytes(tx_msg_header->DataLength);
+    // Convert length to bytes
+    uint32_t len = hal_dlc_code_to_bytes(tx_msg_header->DataLength);
 
-	// Don't overrun buffer element max length
-	if(len > TXQUEUE_DATALEN)
-		return HAL_ERROR;
+    // Don't overrun buffer element max length
+    if(len > TXQUEUE_DATALEN)
+        return HAL_ERROR;
 
-	// Save the header to the circular buffer
-	txqueue.header[txqueue.head] = *tx_msg_header;
+    // Save the header to the circular buffer
+    txqueue.header[txqueue.head] = *tx_msg_header;
 
-	// Copy the data to the circular buffer
-	for(uint8_t i=0; i<len; i++)
-	{
-		txqueue.data[txqueue.head][i] = tx_msg_data[i];
-	}
+    // Copy the data to the circular buffer
+    for(uint8_t i=0; i<len; i++)
+    {
+        txqueue.data[txqueue.head][i] = tx_msg_data[i];
+    }
 
-	// Increment the head pointer
-	txqueue.head = (txqueue.head + 1) % TXQUEUE_LEN;
+    // Increment the head pointer
+    txqueue.head = (txqueue.head + 1) % TXQUEUE_LEN;
 
-	return HAL_OK;
+    return HAL_OK;
 }
 
 
 // Process data from CAN tx/rx circular buffers
 void can_process(void)
 {
-	while((txqueue.tail != txqueue.head) && (HAL_FDCAN_GetTxFifoFreeLevel(&can_handle) > 0))
-	{
-		uint32_t status;
+    while((txqueue.tail != txqueue.head) && (HAL_FDCAN_GetTxFifoFreeLevel(&can_handle) > 0))
+    {
+        uint32_t status;
 
-		// Transmit can frame
-		status = HAL_FDCAN_AddMessageToTxFifoQ(&can_handle, &txqueue.header[txqueue.tail], txqueue.data[txqueue.tail]);
-		txqueue.tail = (txqueue.tail + 1) % TXQUEUE_LEN;
+        // Transmit can frame
+        status = HAL_FDCAN_AddMessageToTxFifoQ(&can_handle, &txqueue.header[txqueue.tail], txqueue.data[txqueue.tail]);
+        txqueue.tail = (txqueue.tail + 1) % TXQUEUE_LEN;
 
-		// This drops the packet if it fails (no retry). Failure is unlikely
-		// since we check if there is a TX mailbox free.
-		if(status != HAL_OK)
-		{
-			error_assert(ERR_CAN_TXFAIL);
-		}
+        // This drops the packet if it fails (no retry). Failure is unlikely
+        // since we check if there is a TX mailbox free.
+        if(status != HAL_OK)
+        {
+            error_assert(ERR_CAN_TXFAIL);
+        }
 
-		led_green_on();
-	}
+        led_green_on();
+    }
 }
 
 
@@ -320,7 +374,7 @@ uint32_t can_rx(FDCAN_RxHeaderTypeDef *rx_msg_header, uint8_t* rx_msg_data)
     uint32_t status;
     status = HAL_FDCAN_GetRxMessage(&can_handle, FDCAN_RX_FIFO0, rx_msg_header, rx_msg_data);
 
-	led_blue_on();
+    led_blue_on();
     return status;
 }
 
@@ -340,5 +394,5 @@ uint8_t is_can_msg_pending(uint8_t fifo)
 // Return reference to CAN handle
 FDCAN_HandleTypeDef* can_gethandle(void)
 {
-	return &can_handle;
+    return &can_handle;
 }

--- a/src/slcan.c
+++ b/src/slcan.c
@@ -33,29 +33,29 @@ int32_t slcan_parse_frame(uint8_t *buf, FDCAN_RxHeaderTypeDef *frame_header, uin
     // Handle classic CAN frames
     if(frame_header->FDFormat == FDCAN_CLASSIC_CAN)
     {
-		// Add character for frame type
-		if (frame_header->RxFrameType == FDCAN_DATA_FRAME)
-		{
-			buf[msg_idx] = 't';
-		} else if (frame_header->RxFrameType == FDCAN_REMOTE_FRAME) {
-			buf[msg_idx] = 'r';
-		}
+        // Add character for frame type
+        if (frame_header->RxFrameType == FDCAN_DATA_FRAME)
+        {
+            buf[msg_idx] = 't';
+        } else if (frame_header->RxFrameType == FDCAN_REMOTE_FRAME) {
+            buf[msg_idx] = 'r';
+        }
     }
     // Handle FD CAN frames
     else
     {
-    	// FD doesn't support remote frames so this must be a data frame
+        // FD doesn't support remote frames so this must be a data frame
 
-    	// Frame with BRS enabled
-    	if(frame_header->BitRateSwitch == FDCAN_BRS_ON)
-    	{
-    		buf[msg_idx] = 'b';
-    	}
-    	// Frame with BRS disabled
-    	else
-    	{
-    		buf[msg_idx] = 'd';
-    	}
+        // Frame with BRS enabled
+        if(frame_header->BitRateSwitch == FDCAN_BRS_ON)
+        {
+            buf[msg_idx] = 'b';
+        }
+        // Frame with BRS disabled
+        else
+        {
+            buf[msg_idx] = 'd';
+        }
     }
 
     // Assume standard identifier
@@ -87,9 +87,9 @@ int32_t slcan_parse_frame(uint8_t *buf, FDCAN_RxHeaderTypeDef *frame_header, uin
 
     // Check bytes value
     if(bytes < 0)
-    	return -1;
+        return -1;
     if(bytes > 64)
-    	return -1;
+        return -1;
 
     // Add data bytes
     for (uint8_t j = 0; j < bytes; j++)
@@ -119,17 +119,17 @@ int32_t slcan_parse_frame(uint8_t *buf, FDCAN_RxHeaderTypeDef *frame_header, uin
 // Parse an incoming slcan command from the USB CDC port
 int32_t slcan_parse_str(uint8_t *buf, uint8_t len)
 {
-	// Set default header. All values overridden below as needed.
-	FDCAN_TxHeaderTypeDef frame_header =
-	{
-		.TxFrameType = FDCAN_DATA_FRAME,
-		.FDFormat = FDCAN_CLASSIC_CAN, // default to classic frame
-		.IdType = FDCAN_STANDARD_ID, // default to standard ID
-		.BitRateSwitch = FDCAN_BRS_OFF, // no bitrate switch
+    // Set default header. All values overridden below as needed.
+    FDCAN_TxHeaderTypeDef frame_header =
+    {
+        .TxFrameType = FDCAN_DATA_FRAME,
+        .FDFormat = FDCAN_CLASSIC_CAN, // default to classic frame
+        .IdType = FDCAN_STANDARD_ID, // default to standard ID
+        .BitRateSwitch = FDCAN_BRS_OFF, // no bitrate switch
         .ErrorStateIndicator = FDCAN_ESI_ACTIVE, // error active
         .TxEventFifoControl = FDCAN_NO_TX_EVENTS, // don't record tx events
         .MessageMarker = 0, // ?
-	};
+    };
     uint8_t frame_data[64] = {0};
 
 
@@ -151,149 +151,142 @@ int32_t slcan_parse_str(uint8_t *buf, uint8_t len)
     // Handle each incoming command
     switch(buf[0])
     {
-    	// Open channel
-		case 'O':
-			can_enable();
-			return 0;
+        // Open channel
+        case 'O':
+            can_enable();
+            return 0;
 
-		// Close channel
-		case 'C':
-	        can_disable();
-	        return 0;
+        // Close channel
+        case 'C':
+            can_disable();
+            return 0;
 
-	    // Set nominal bitrate
-		case 'S':
+        // Set nominal bitrate
+        case 'S':
 
-	    	// Check for valid bitrate
-	    	if(buf[1] >= CAN_BITRATE_INVALID)
-	    	{
-	    		return -1;
-	    	}
-
-			can_set_bitrate(buf[1]);
-	        return 0;
-
-	    // Set data bitrate
-		case 'Y':
-
-	    	// Check for valid bitrate
-	    	if(buf[1] == 2)
-	    	{
-                // Set data bitrate to 2M preset
-                can_set_data_bitrate(CAN_DATA_BITRATE_2M);
-	    	}
-            else if(buf[1] == 5)
+            // Check for valid bitrate
+            if(buf[1] >= CAN_BITRATE_INVALID)
             {
-                // Set data bitrate to 5M preset
-                can_set_data_bitrate(CAN_DATA_BITRATE_5M);
-            }
-            else
-            {
-                // Invalid bitrate
                 return -1;
             }
 
-	        return 0;
+            can_set_bitrate(buf[1]);
+            return 0;
+
+        // Set data bitrate
+        case 'Y':
+
+            // Check for valid bitrate
+            switch (buf[1]) {
+                case CAN_DATA_BITRATE_1M:
+                case CAN_DATA_BITRATE_2M:
+                case CAN_DATA_BITRATE_4M:
+                case CAN_DATA_BITRATE_5M:
+                    can_set_data_bitrate(buf[1]);
+                    return 0;
+                default:
+                    // Invalid bitrate
+                    return -1;
+            }
+
+        // FIXME: Nonstandard!
+        case 'M':
+            // Set mode command
+            if (buf[1] == 1)
+            {
+                // Mode 1: silent
+                can_set_silent(1);
+            } else {
+                // Default to normal mode
+                can_set_silent(0);
+            }
+            return 0;
 
 
-	    // FIXME: Nonstandard!
-		case 'M':
-	        // Set mode command
-	        if (buf[1] == 1)
-	        {
-	            // Mode 1: silent
-	            can_set_silent(1);
-	        } else {
-	            // Default to normal mode
-	            can_set_silent(0);
-	        }
-	        return 0;
+        // FIXME: Nonstandard!
+        case 'A':
+            // Set autoretry command
+            if (buf[1] == 1)
+            {
+                // Mode 1: autoretry enabled (default)
+                can_set_autoretransmit(ENABLE);
+            } else {
+                // Mode 0: autoretry disabled
+                can_set_autoretransmit(DISABLE);
+            }
+            return 0;
 
 
-	    // FIXME: Nonstandard!
-		case 'A':
-	        // Set autoretry command
-	        if (buf[1] == 1)
-	        {
-	            // Mode 1: autoretry enabled (default)
-	            can_set_autoretransmit(ENABLE);
-	        } else {
-	            // Mode 0: autoretry disabled
-	            can_set_autoretransmit(DISABLE);
-	        }
-	        return 0;
+        // FIXME: Nonstandard!
+        case 'V':
+        {
+            // Report firmware version and remote
+            cdc_transmit((uint8_t*)fw_id, strlen(fw_id));
+            return 0;
+        }
 
-
-	    // FIXME: Nonstandard!
-		case 'V':
-		{
-	        // Report firmware version and remote
-			cdc_transmit((uint8_t*)fw_id, strlen(fw_id));
-	        return 0;
-		}
-
-	    // FIXME: Nonstandard!
-		case 'E':
-		{
-	        // Report error register
-			char errstr[64] = {0};
-			snprintf_(errstr, 64, "CANable Error Register: %X", (unsigned int)error_reg());
-			cdc_transmit((uint8_t*)errstr, strlen(errstr));
-	        return 0;
-		}
+        // FIXME: Nonstandard!
+        case 'E':
+        {
+            // Report error register
+            char errstr[64] = {0};
+            snprintf_(errstr, 64, "CANable Error Register: %X", (unsigned int)error_reg());
+            cdc_transmit((uint8_t*)errstr, strlen(errstr));
+            return 0;
+        }
         
 
-		// Transmit data frame command
-		case 'T':
-	    	frame_header.IdType = FDCAN_EXTENDED_ID;
-	    	break;
-		case 't':
-	        break;
+        // Transmit data frame command
+        case 'T':
+            frame_header.IdType = FDCAN_EXTENDED_ID;
+            break;
+        case 't':
+            break;
 
-		// Transmit remote frame command
-		case 'r':
-	    	frame_header.TxFrameType = FDCAN_REMOTE_FRAME;
-	    	break;
-		case 'R':
-	    	frame_header.IdType = FDCAN_EXTENDED_ID;
-	    	frame_header.TxFrameType = FDCAN_REMOTE_FRAME;
-	    	break;
+        // Transmit remote frame command
+        case 'r':
+            frame_header.TxFrameType = FDCAN_REMOTE_FRAME;
+            break;
+        case 'R':
+            frame_header.IdType = FDCAN_EXTENDED_ID;
+            frame_header.TxFrameType = FDCAN_REMOTE_FRAME;
+            break;
 
 
 
-	    // CANFD transmit - no BRS
-		case 'd':
-	        frame_header.FDFormat = FDCAN_FD_CAN;
-	        break;
-	        //frame_header.BitRateSwitch = FDCAN_BRS_ON
-		case 'D':
-	        frame_header.FDFormat = FDCAN_FD_CAN;
-	    	frame_header.IdType = FDCAN_EXTENDED_ID;
-			// Transmit CANFD frame
-			break;
+        // CANFD transmit - no BRS
+        case 'd':
+            frame_header.FDFormat = FDCAN_FD_CAN;
+            break;
+            //frame_header.BitRateSwitch = FDCAN_BRS_ON
+        case 'D':
+            frame_header.FDFormat = FDCAN_FD_CAN;
+            frame_header.IdType = FDCAN_EXTENDED_ID;
+            // Transmit CANFD frame
+            break;
 
-		// CANFD transmit - with BRS
-		case 'b':
-			frame_header.FDFormat = FDCAN_FD_CAN;
-			frame_header.BitRateSwitch = FDCAN_BRS_ON;
-			break;
-			// Fallthrough
-		case 'B':
-			frame_header.FDFormat = FDCAN_FD_CAN;
-			frame_header.BitRateSwitch = FDCAN_BRS_ON;
-			frame_header.IdType = FDCAN_EXTENDED_ID;
-			break;
-			// Transmit CANFD frame
-			break;
+        // CANFD transmit - with BRS
+        case 'b':
+            frame_header.FDFormat = FDCAN_FD_CAN;
+            frame_header.BitRateSwitch = FDCAN_BRS_ON;
+            break;
+            // Fallthrough
+        case 'B':
+            frame_header.FDFormat = FDCAN_FD_CAN;
+            frame_header.BitRateSwitch = FDCAN_BRS_ON;
+            frame_header.IdType = FDCAN_EXTENDED_ID;
+            break;
+            // Transmit CANFD frame
+            break;
 
-		case 'X':
-			// TODO: Firmware update
-			#warning "TODO: Implement firmware update via command"
-			break;
+        case 'X':
+            // TODO: Firmware update
+            #warning "TODO: Implement firmware update via command"
+            break;
 
-		// Invalid command
-		default:
-			return -1;
+        // Invalid command
+        default:
+            return -1;
     }
 
     // Start parsing at second byte (skip command byte)
@@ -307,14 +300,14 @@ int32_t slcan_parse_str(uint8_t *buf, uint8_t len)
 
     // Update length if message is extended ID
     if(frame_header.IdType == FDCAN_EXTENDED_ID)
-    	id_len = SLCAN_EXT_ID_LEN;
+        id_len = SLCAN_EXT_ID_LEN;
 
     // Iterate through ID bytes
-	while(parse_loc <= id_len)
-	{
-		frame_header.Identifier *= 16;
-		frame_header.Identifier += buf[parse_loc++];
-	}
+    while(parse_loc <= id_len)
+    {
+        frame_header.Identifier *= 16;
+        frame_header.Identifier += buf[parse_loc++];
+    }
 
     // Attempt to parse DLC and check sanity
     uint8_t dlc_code_raw = buf[parse_loc++];
@@ -322,7 +315,7 @@ int32_t slcan_parse_str(uint8_t *buf, uint8_t len)
     // If dlc is too long for an FD frame
     if(frame_header.FDFormat == FDCAN_FD_CAN && dlc_code_raw > 0xF)
     {
-    	return -1;
+        return -1;
     }
     if(frame_header.FDFormat == FDCAN_CLASSIC_CAN && dlc_code_raw > 0x8)
     {
@@ -336,9 +329,9 @@ int32_t slcan_parse_str(uint8_t *buf, uint8_t len)
     int8_t bytes_in_msg = hal_dlc_code_to_bytes(frame_header.DataLength);
 
     if(bytes_in_msg < 0)
-    	return -1;
+        return -1;
     if(bytes_in_msg > 64)
-    	return -1;
+        return -1;
 
     // Parse data
     // TODO: Guard against walking off the end of the string!
@@ -358,57 +351,57 @@ int32_t slcan_parse_str(uint8_t *buf, uint8_t len)
 // Convert a FDCAN_data_length_code to number of bytes in a message
 int8_t hal_dlc_code_to_bytes(uint32_t hal_dlc_code)
 {
-	switch(hal_dlc_code)
-	{
-		case FDCAN_DLC_BYTES_0:
-			return 0;
-		case FDCAN_DLC_BYTES_1:
-			return 1;
-		case FDCAN_DLC_BYTES_2:
-			return 2;
-		case FDCAN_DLC_BYTES_3:
-			return 3;
-		case FDCAN_DLC_BYTES_4:
-			return 4;
-		case FDCAN_DLC_BYTES_5:
-			return 5;
-		case FDCAN_DLC_BYTES_6:
-			return 6;
-		case FDCAN_DLC_BYTES_7:
-			return 7;
-		case FDCAN_DLC_BYTES_8:
-			return 8;
-		case FDCAN_DLC_BYTES_12:
-			return 12;
-		case FDCAN_DLC_BYTES_16:
-			return 16;
-		case FDCAN_DLC_BYTES_20:
-			return 20;
-		case FDCAN_DLC_BYTES_24:
-			return 24;
-		case FDCAN_DLC_BYTES_32:
-			return 32;
-		case FDCAN_DLC_BYTES_48:
-			return 48;
-		case FDCAN_DLC_BYTES_64:
-			return 64;
-		default:
-			return -1;
-	}
+    switch(hal_dlc_code)
+    {
+        case FDCAN_DLC_BYTES_0:
+            return 0;
+        case FDCAN_DLC_BYTES_1:
+            return 1;
+        case FDCAN_DLC_BYTES_2:
+            return 2;
+        case FDCAN_DLC_BYTES_3:
+            return 3;
+        case FDCAN_DLC_BYTES_4:
+            return 4;
+        case FDCAN_DLC_BYTES_5:
+            return 5;
+        case FDCAN_DLC_BYTES_6:
+            return 6;
+        case FDCAN_DLC_BYTES_7:
+            return 7;
+        case FDCAN_DLC_BYTES_8:
+            return 8;
+        case FDCAN_DLC_BYTES_12:
+            return 12;
+        case FDCAN_DLC_BYTES_16:
+            return 16;
+        case FDCAN_DLC_BYTES_20:
+            return 20;
+        case FDCAN_DLC_BYTES_24:
+            return 24;
+        case FDCAN_DLC_BYTES_32:
+            return 32;
+        case FDCAN_DLC_BYTES_48:
+            return 48;
+        case FDCAN_DLC_BYTES_64:
+            return 64;
+        default:
+            return -1;
+    }
 }
 
 // Convert a standard 0-F CANFD length code to a FDCAN_data_length_code
 // TODO: make this a macro
 static uint32_t __std_dlc_code_to_hal_dlc_code(uint8_t dlc_code)
 {
-	return (uint32_t)dlc_code << 16;
+    return (uint32_t)dlc_code << 16;
 }
 
 // Convert a FDCAN_data_length_code to a standard 0-F CANFD length code
 // TODO: make this a macro
 static uint8_t __hal_dlc_code_to_std_dlc_code(uint32_t hal_dlc_code)
 {
-	return hal_dlc_code >> 16;
+    return hal_dlc_code >> 16;
 }
 
 

--- a/src/system.c
+++ b/src/system.c
@@ -31,7 +31,7 @@ void system_init(void)
     RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
     RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSI;
     RCC_OscInitStruct.PLL.PLLM = RCC_PLLM_DIV4;
-    RCC_OscInitStruct.PLL.PLLN = 85;
+    RCC_OscInitStruct.PLL.PLLN = 80;
     RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV2;
     RCC_OscInitStruct.PLL.PLLQ = RCC_PLLQ_DIV2;
     RCC_OscInitStruct.PLL.PLLR = RCC_PLLR_DIV2;


### PR DESCRIPTION
[Copied from the original pull request]

This PR changes the following:
- Changes system clock from 170 to 160MHz, making it possible to easily calculate high bit rates
- Fixes low bit rates (prescaler must be smaller than 512)
- Implements additional bit rates, such as 1M and 4M
- Implements transceiver delay (very useful, especially for isolated transceivers with the high loopback delay)
- Adds missing confirmation messages in SLCAN protocol

Important
There is a bug in cangaroo SW, that sets the data bit rate to 2M regardless of the user's choice. I already tested the fix, will clean up the code and prepare a PR.