### PR TITLE
Fix usb buffer overflow detection

### DIFF
--- a/src/usbd_cdc_if.c
+++ b/src/usbd_cdc_if.c
@@ -253,7 +253,6 @@ void cdc_transmit(uint8_t* buf, uint16_t len)
     if( ((txbuf.head + len) % USBTXQUEUE_LEN) == txbuf.tail)    // FIXME no error if size of enqueued data > size of empty area
     {
         error_assert(ERR_FULLBUF_USBTX);
-        return;    // FIXME this will leave the system interrupt disabled
     }
     else
     {

--- a/src/usbd_cdc_if.c
+++ b/src/usbd_cdc_if.c
@@ -25,31 +25,31 @@ void cdc_process(void);
 
 USBD_CDC_ItfTypeDef USBD_Interface_fops_FS =
 {
-  CDC_Init_FS,
-  CDC_DeInit_FS,
-  CDC_Control_FS,
-  CDC_Receive_FS
+    CDC_Init_FS,
+    CDC_DeInit_FS,
+    CDC_Control_FS,
+    CDC_Receive_FS
 };
 
 
 // Initializes the CDC media low layer over the FS USB IP
 static int8_t CDC_Init_FS(void)
 {
-	rxbuf.head = 0;
-	rxbuf.tail = 0;
-	txbuf.head = 0;
-	txbuf.tail = 0;
+    rxbuf.head = 0;
+    rxbuf.tail = 0;
+    txbuf.head = 0;
+    txbuf.tail = 0;
 
-	USBD_CDC_SetTxBuffer(&hUsbDeviceFS, tx_linbuf, 0);
-	USBD_CDC_SetRxBuffer(&hUsbDeviceFS, rxbuf.buf[rxbuf.head]);
-	return (USBD_OK);
+    USBD_CDC_SetTxBuffer(&hUsbDeviceFS, tx_linbuf, 0);
+    USBD_CDC_SetRxBuffer(&hUsbDeviceFS, rxbuf.buf[rxbuf.head]);
+    return (USBD_OK);
 }
 
 
 // DeInitializes the CDC media low layer
 static int8_t CDC_DeInit_FS(void)
 {
-	return (USBD_OK);
+    return (USBD_OK);
 }
 
 /**
@@ -61,28 +61,28 @@ static int8_t CDC_DeInit_FS(void)
   */
 static int8_t CDC_Control_FS(uint8_t cmd, uint8_t* pbuf, uint16_t length)
 {
-  /* USER CODE BEGIN 5 */
-  switch(cmd)
-  {
-    case CDC_SEND_ENCAPSULATED_COMMAND:
+    /* USER CODE BEGIN 5 */
+    switch(cmd)
+    {
+        case CDC_SEND_ENCAPSULATED_COMMAND:
 
-    break;
+            break;
 
-    case CDC_GET_ENCAPSULATED_RESPONSE:
+        case CDC_GET_ENCAPSULATED_RESPONSE:
 
-    break;
+            break;
 
-    case CDC_SET_COMM_FEATURE:
+        case CDC_SET_COMM_FEATURE:
 
-    break;
+            break;
 
-    case CDC_GET_COMM_FEATURE:
+        case CDC_GET_COMM_FEATURE:
 
-    break;
+            break;
 
-    case CDC_CLEAR_COMM_FEATURE:
+        case CDC_CLEAR_COMM_FEATURE:
 
-    break;
+            break;
 
   /*******************************************************************************/
   /* Line Coding Structure                                                       */
@@ -101,34 +101,35 @@ static int8_t CDC_Control_FS(uint8_t cmd, uint8_t* pbuf, uint16_t length)
   /*                                        4 - Space                            */
   /* 6      | bDataBits  |   1   | Number Data bits (5, 6, 7, 8 or 16).          */
   /*******************************************************************************/
-    case CDC_SET_LINE_CODING:
+        case CDC_SET_LINE_CODING:
 
-    break;
+            break;
 
-    case CDC_GET_LINE_CODING:
-        pbuf[0] = (uint8_t)(115200);
-	pbuf[1] = (uint8_t)(115200 >> 8);
-	pbuf[2] = (uint8_t)(115200 >> 16);
-	pbuf[3] = (uint8_t)(115200 >> 24);
-	pbuf[4] = 0; // stop bits (1)
-	pbuf[5] = 0; // parity (none)
-	pbuf[6] = 8; // number of bits (8)
-        break;
+        case CDC_GET_LINE_CODING:
+            pbuf[0] = (uint8_t)(115200);
+            pbuf[1] = (uint8_t)(115200 >> 8);
+            pbuf[2] = (uint8_t)(115200 >> 16);
+            pbuf[3] = (uint8_t)(115200 >> 24);
+            pbuf[4] = 0; // stop bits (1)
+            pbuf[5] = 0; // parity (none)
+            pbuf[6] = 8; // number of bits (8)
+            break;
 
-    case CDC_SET_CONTROL_LINE_STATE:
+        case CDC_SET_CONTROL_LINE_STATE:
 
-    break;
+            break;
 
-    case CDC_SEND_BREAK:
+        case CDC_SEND_BREAK:
 
-    break;
+            break;
 
-  default:
-    break;
-  }
+        default:
 
-  return (USBD_OK);
-  /* USER CODE END 5 */
+            break;
+    }
+
+    return (USBD_OK);
+    /* USER CODE END 5 */
 }
 
 /**
@@ -149,97 +150,97 @@ static int8_t CDC_Control_FS(uint8_t cmd, uint8_t* pbuf, uint16_t length)
 
 static int8_t CDC_Receive_FS(uint8_t* Buf, uint32_t *Len)
 {
-	// Check for overflow!
-	// If when we increment the head we're going to hit the tail
-	// (if we're filling the last spot in the queue)
-	// FIXME: Use a "full" variable instead of wasting one
-	// spot in the cirbuf as we are doing now
-	if( ((rxbuf.head + 1) % NUM_RX_BUFS) == rxbuf.tail)
-	{
-		error_assert(ERR_FULLBUF_USBRX);
+    // Check for overflow!
+    // If when we increment the head we're going to hit the tail
+    // (if we're filling the last spot in the queue)
+    // FIXME: Use a "full" variable instead of wasting one
+    // spot in the cirbuf as we are doing now
+    if( ((rxbuf.head + 1) % NUM_RX_BUFS) == rxbuf.tail)
+    {
+        error_assert(ERR_FULLBUF_USBRX);
 
-		// Listen again on the same buffer. Old data will be overwritten.
-	    USBD_CDC_SetRxBuffer(&hUsbDeviceFS, rxbuf.buf[rxbuf.head]);
-	    USBD_CDC_ReceivePacket(&hUsbDeviceFS);
-		return HAL_ERROR;
-	}
-	else
-	{
-		// Save off length
-		rxbuf.msglen[rxbuf.head] = *Len;
-		rxbuf.head = (rxbuf.head + 1) % NUM_RX_BUFS;
+        // Listen again on the same buffer. Old data will be overwritten.
+        USBD_CDC_SetRxBuffer(&hUsbDeviceFS, rxbuf.buf[rxbuf.head]);
+        USBD_CDC_ReceivePacket(&hUsbDeviceFS);
+        return HAL_ERROR;
+    }
+    else
+    {
+        // Save off length
+        rxbuf.msglen[rxbuf.head] = *Len;
+        rxbuf.head = (rxbuf.head + 1) % NUM_RX_BUFS;
 
-		// Start listening on next buffer. Previous buffer will be processed in main loop.
-	    USBD_CDC_SetRxBuffer(&hUsbDeviceFS, rxbuf.buf[rxbuf.head]);
-	    USBD_CDC_ReceivePacket(&hUsbDeviceFS);
-	    return (USBD_OK);
-	}
+        // Start listening on next buffer. Previous buffer will be processed in main loop.
+        USBD_CDC_SetRxBuffer(&hUsbDeviceFS, rxbuf.buf[rxbuf.head]);
+        USBD_CDC_ReceivePacket(&hUsbDeviceFS);
+        return (USBD_OK);
+    }
 }
 
 
 // Process incoming and outgoing USB-CDC data
 void cdc_process(void)
 {
-	// Process transmit buffer
+    // Process transmit buffer
     USBD_CDC_HandleTypeDef *hcdc = (USBD_CDC_HandleTypeDef*)hUsbDeviceFS.pClassData;
     if(hcdc->TxState == 0)
     {
-    	uint16_t linbuf_ctr = 0;
-    	while(txbuf.tail != txbuf.head)
-    	{
-    		tx_linbuf[linbuf_ctr++] = txbuf.data[txbuf.tail];
-    		txbuf.tail = (txbuf.tail + 1UL) % USBTXQUEUE_LEN;
+        uint16_t linbuf_ctr = 0;
+        while(txbuf.tail != txbuf.head)
+        {
+            tx_linbuf[linbuf_ctr++] = txbuf.data[txbuf.tail];
+            txbuf.tail = (txbuf.tail + 1UL) % USBTXQUEUE_LEN;
 
-    		// Take up to the number of bytes to fill the linbuf
-    		if(linbuf_ctr >= TX_LINBUF_SIZE)
-    			break;
-    	}
+            // Take up to the number of bytes to fill the linbuf
+            if(linbuf_ctr >= TX_LINBUF_SIZE)
+                break;
+            }
 
-    	if(linbuf_ctr > 0)
-    	{
-			// Set transmit buffer and start TX
-			USBD_CDC_SetTxBuffer(&hUsbDeviceFS, tx_linbuf, linbuf_ctr);
-			USBD_CDC_TransmitPacket(&hUsbDeviceFS);
-    	}
+            if(linbuf_ctr > 0)
+            {
+                // Set transmit buffer and start TX
+                USBD_CDC_SetTxBuffer(&hUsbDeviceFS, tx_linbuf, linbuf_ctr);
+                USBD_CDC_TransmitPacket(&hUsbDeviceFS);
+            }
     }
 
-	// Process receive buffer
+    // Process receive buffer
     system_irq_disable();
-	if(rxbuf.tail != rxbuf.head)
-	{
-		//  Process one whole buffer
-		for (uint32_t i = 0; i < rxbuf.msglen[rxbuf.tail]; i++)
-		{
-		   if (rxbuf.buf[rxbuf.tail][i] == '\r')
-		   {
-			   //int8_t result =
-			   slcan_parse_str(slcan_str, slcan_str_index);
+    if(rxbuf.tail != rxbuf.head)
+    {
+        //  Process one whole buffer
+        for (uint32_t i = 0; i < rxbuf.msglen[rxbuf.tail]; i++)
+	    {
+            if (rxbuf.buf[rxbuf.tail][i] == '\r')
+            {
+                //int8_t result =
+                slcan_parse_str(slcan_str, slcan_str_index);
 
-			   // Success
-			   //if(result == 0)
-			   //    CDC_Transmit_FS("\n", 1);
-			   // Failure
-			   //else
-			   //    CDC_Transmit_FS("\a", 1);
+                // Success
+                //if(result == 0)
+                //    CDC_Transmit_FS("\n", 1);
+                // Failure
+                //else
+                //    CDC_Transmit_FS("\a", 1);
 
-			   slcan_str_index = 0;
-		   }
-		   else
-		   {
-			   // Check for overflow of buffer
-			   if(slcan_str_index >= SLCAN_MTU)
-			   {
-				   // TODO: Return here and discard this CDC buffer?
-				   slcan_str_index = 0;
-			   }
+                slcan_str_index = 0;
+            }
+            else
+            {
+                // Check for overflow of buffer
+                if(slcan_str_index >= SLCAN_MTU)
+                {
+                    // TODO: Return here and discard this CDC buffer?
+                    slcan_str_index = 0;
+                }
 
-			   slcan_str[slcan_str_index++] = rxbuf.buf[rxbuf.tail][i];
-		   }
-		}
+                slcan_str[slcan_str_index++] = rxbuf.buf[rxbuf.tail][i];
+            }
+        }
 
-		// Move on to next buffer
-		rxbuf.tail = (rxbuf.tail + 1) % NUM_RX_BUFS;
-	}
+        // Move on to next buffer
+        rxbuf.tail = (rxbuf.tail + 1) % NUM_RX_BUFS;
+    }
     system_irq_enable();
 
 }
@@ -248,24 +249,24 @@ void cdc_process(void)
 // Enqueue data for transmission over USB CDC to host
 void cdc_transmit(uint8_t* buf, uint16_t len)
 {
-	system_irq_disable();
-	if( ((txbuf.head + len) % USBTXQUEUE_LEN) == txbuf.tail)
-	{
-		error_assert(ERR_FULLBUF_USBTX);
-    	return;
+    system_irq_disable();
+    if( ((txbuf.head + len) % USBTXQUEUE_LEN) == txbuf.tail)    // FIXME no error if size of enqueued data > size of empty area
+    {
+        error_assert(ERR_FULLBUF_USBTX);
+        return;    // FIXME this will leave the system interrupt disabled
     }
-	else
-	{
-		// Copy data
-	    for (uint32_t i=0; i < len; i++)
-	    {
-	    	txbuf.data[txbuf.head] = buf[i];
+    else
+    {
+        // Copy data
+        for (uint32_t i=0; i < len; i++)
+        {
+            txbuf.data[txbuf.head] = buf[i];
 
-		    // Increment the head
-			txbuf.head = (txbuf.head + 1UL) % USBTXQUEUE_LEN;
-	    }
+            // Increment the head
+            txbuf.head = (txbuf.head + 1UL) % USBTXQUEUE_LEN;
+        }
 
-	}
+    }
     system_irq_enable();
 }
 

--- a/src/usbd_cdc_if.c
+++ b/src/usbd_cdc_if.c
@@ -250,21 +250,7 @@ void cdc_process(void)
 void cdc_transmit(uint8_t* buf, uint16_t len)
 {
     system_irq_disable();
-    if( ((txbuf.head + len) % USBTXQUEUE_LEN) == txbuf.tail)    // FIXME no error if size of enqueued data > size of empty area
-    //
-    // txbuf.tail: First in data = First out data
-    // head: Head of empty area = Last in data + 1
-    //
-    // data count in q: (txbuf.head - txbuf.tail + USBTXQUEUE_LEN) % USBTXQUEUE_LEN
-    // size of q: USBTXQUEUE_LEN - 1U // we cannot set tail = head. it's empty.
-    //
-    // usable size: "size of q" - "data count in q"
-    //            = (USBTXQUEUE_LEN - 1U) - (txbuf.head - txbuf.tail + USBTXQUEUE_LEN) % USBTXQUEUE_LEN
-    //            = (USBTXQUEUE_LEN - 1U - txbuf.head + txbuf.tail) % USBTXQUEUE_LEN
-    //
-    // It should be like
-    //if (len > (USBTXQUEUE_LEN - 1U - txbuf.head + txbuf.tail) % USBTXQUEUE_LEN)
-    // ?
+    if (len > (USBTXQUEUE_LEN + txbuf.tail - txbuf.head - 1U) % USBTXQUEUE_LEN)
     {
         error_assert(ERR_FULLBUF_USBTX);
     }

--- a/src/usbd_cdc_if.c
+++ b/src/usbd_cdc_if.c
@@ -251,6 +251,20 @@ void cdc_transmit(uint8_t* buf, uint16_t len)
 {
     system_irq_disable();
     if( ((txbuf.head + len) % USBTXQUEUE_LEN) == txbuf.tail)    // FIXME no error if size of enqueued data > size of empty area
+    //
+    // txbuf.tail: First in data = First out data
+    // head: Head of empty area = Last in data + 1
+    //
+    // data count in q: (txbuf.head - txbuf.tail + USBTXQUEUE_LEN) % USBTXQUEUE_LEN
+    // size of q: USBTXQUEUE_LEN - 1U // we cannot set tail = head. it's empty.
+    //
+    // usable size: "size of q" - "data count in q"
+    //            = (USBTXQUEUE_LEN - 1U) - (txbuf.head - txbuf.tail + USBTXQUEUE_LEN) % USBTXQUEUE_LEN
+    //            = (USBTXQUEUE_LEN - 1U - txbuf.head + txbuf.tail) % USBTXQUEUE_LEN
+    //
+    // It should be like
+    //if (len >= (USBTXQUEUE_LEN - 1U - txbuf.head + txbuf.tail) % USBTXQUEUE_LEN)
+    // ?
     {
         error_assert(ERR_FULLBUF_USBTX);
     }

--- a/src/usbd_cdc_if.c
+++ b/src/usbd_cdc_if.c
@@ -263,7 +263,7 @@ void cdc_transmit(uint8_t* buf, uint16_t len)
     //            = (USBTXQUEUE_LEN - 1U - txbuf.head + txbuf.tail) % USBTXQUEUE_LEN
     //
     // It should be like
-    //if (len >= (USBTXQUEUE_LEN - 1U - txbuf.head + txbuf.tail) % USBTXQUEUE_LEN)
+    //if (len > (USBTXQUEUE_LEN - 1U - txbuf.head + txbuf.tail) % USBTXQUEUE_LEN)
     // ?
     {
         error_assert(ERR_FULLBUF_USBTX);


### PR DESCRIPTION
With this fix, CANable will always detect USB Tx buffer overflow .
The overflow was detected as:
```
CANable Error Register: 40
```