### PR TITLE
Add Z command to set time stamp on/off for received CAN frame

### DIFF
--- a/inc/slcan.h
+++ b/inc/slcan.h
@@ -1,8 +1,20 @@
 #ifndef _SLCAN_H
 #define _SLCAN_H
 
+// Timestamp mode
+enum slcan_timestamp_mode
+{
+    SLCAN_TIMESTAMP_OFF = 0,
+    SLCAN_TIMESTAMP_RX_MILI,
+    //SLCAN_TIMESTAMP_RX_MICRO,     // Reserved
+    //SLCAN_TIMESTAMP_RXTX_MILI,    // TODO
+    //SLCAN_TIMESTAMP_RXTX_MICRO,   // Maybe
+
+    SLCAN_TIMESTAMP_INVALID,
+};
+
 // Maximum rx buffer len
-#define SLCAN_MTU 138 + 1 + 16 // canfd 64 frame plus \r plus some padding
+#define SLCAN_MTU (1 + 8 + 1 + 128 + 4 + 1 + 16) /* cmd 1 plus id 8 plus dlc 1 plus data 128 plus timestamp 4 plus \r plus some padding */
 #define SLCAN_STD_ID_LEN 3
 #define SLCAN_EXT_ID_LEN 8
 

--- a/test/test_slcan.py
+++ b/test/test_slcan.py
@@ -161,6 +161,11 @@ class SlcanTestCase(unittest.TestCase):
         self.send(b"C\r")
         self.assertEqual(self.receive(), b"\r")
 
+        # invalid format
+        cmd = "S" + "\r"
+        self.send(cmd.encode())
+        self.assertEqual(self.receive(), b"\a")
+
 
     def test_Y_command(self):
         # check response to Y with CAN port closed
@@ -195,6 +200,51 @@ class SlcanTestCase(unittest.TestCase):
 
         self.send(b"C\r")
         self.assertEqual(self.receive(), b"\r")
+
+        # invalid format
+        cmd = "Y" + "\r"
+        self.send(cmd.encode())
+        self.assertEqual(self.receive(), b"\a")
+
+
+    def test_Z_command(self):
+        # check response to Z with CAN port closed
+        for idx in range(0, 10):
+            cmd = "Z" + str(idx) + "\r"
+            self.send(cmd.encode())
+            if idx in (0, 1):
+                self.assertEqual(self.receive(), b"\r")
+            else:
+                self.assertEqual(self.receive(), b"\a")
+
+        # check response to Z in CAN normal mode
+        self.send(b"O\r")
+        self.assertEqual(self.receive(), b"\r")
+
+        for idx in range(0, 10):
+            cmd = "Z" + str(idx) + "\r"
+            self.send(cmd.encode())
+            self.assertEqual(self.receive(), b"\a")
+
+        self.send(b"C\r")
+        self.assertEqual(self.receive(), b"\r")
+
+        # check response to Z in CAN silent mode
+        self.send(b"L\r")
+        self.assertEqual(self.receive(), b"\r")
+
+        for idx in range(0, 10):
+            cmd = "Z" + str(idx) + "\r"
+            self.send(cmd.encode())
+            self.assertEqual(self.receive(), b"\a")
+
+        self.send(b"C\r")
+        self.assertEqual(self.receive(), b"\r")
+
+        # invalid format
+        cmd = "Z" + "\r"
+        self.send(cmd.encode())
+        self.assertEqual(self.receive(), b"\a")
 
 
     def test_send_command(self):


### PR DESCRIPTION
The on/off is stored in volatile memory.
This PR also includes further improvement to the format check of incoming slcan command.